### PR TITLE
Enhance AIO integration with autosave, logging, and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,10 @@ RevPiEpics.init(
 | `DRVH` | High limit (outputs) | float | `100.0` |
 | `autosave_multiplier` | Save AIO multiplier to disk | bool | `True` |
 | `autosave_offset` | Save AIO offset to disk | bool | `True` |
+| `autosave_params` | Save both AIO multiplier & offset | bool | `True` |
 | `autosave` | Native PV field autosave | bool/list | `True`, `["PREC", "EGU"]` |
+| `initial_multiplier` | Override default AIO scale | float | `1.5` |
+| `initial_offset` | Override default AIO offset | float | `20.0` |
 
 ## 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -250,20 +250,25 @@ RevPiEpics.start(dispatcher=dispatcher)
 ### Initialization Parameters
 
 ```python
-RevPiEpics.init(
-    debug=True,          # Enable debug messages
-    cycletime=100,       # Update cycle in ms (default: 200ms)
-    auto_prefix=True,    # Use PiCtory names for prefixes
-    cleanup=True,        # Enable automatic cleanup on exit. 
-                         # Resets the default input/output value (PiControl) before exiting
-    autosave=True,       # Enable global state autosave
-    autosave_dir="/tmp", # Directory to store the softsav backup file
-    autosave_name="my_ioc", # Custom name for the .softsav file
-    autosave_period=10.0 # Autosave frequency in seconds
-)
+RevPiEpics.init()
 ```
 
+| Parameter | Description | Type | Default |
+|-----------|-------------|------|---------|
+| `cycletime` | Update cycle in milliseconds (min 20ms) | int | `200` |
+| `debug` | Enable debug messages and colored logs | bool | `False` |
+| `cleanup` | Enable PiControl cleanup on application exit. Resets the default input/output value (PiControl) before exiting | bool | `True` |
+| `auto_prefix` | Use PiCtory parent devices for PV prefixes | bool | `False` |
+| `autosave` | Enable `pythonSoftIOC` global state saving | bool | `False` |
+| `autosave_dir` | Directory to store `.softsav` backup files | str | `None` |
+| `autosave_name` | Name prefix for the generated save file | str | `"revpiepics"` |
+| `autosave_period` | Frequency of autosave in seconds | float | `30.0` |
+
 ### PV Configuration Options
+
+```python
+RevPiEpics.builder()
+```
 
 | Parameter | Description | Type | Example |
 |-----------|-------------|------|---------|

--- a/README.md
+++ b/README.md
@@ -88,8 +88,18 @@ ai2 = RevPiEpics.builder("OutputStatus_1_i06", "Out1Status")  # PV: TEST:Out1Sta
 
 # Examples with different I/O types
 ai3 = RevPiEpics.builder("InputStatus_1_i06")   # Input Status
-ai4 = RevPiEpics.builder(io_name="InputValue_2_i01", pv_name="IN2_1")    # Analog input / PV: TEST:IN2_1
-ai5 = RevPiEpics.builder("InputStatus_1_i01")
+
+# Analog input with autosave configuration
+ai4 = RevPiEpics.builder(
+    io_name="InputValue_2_i01", 
+    pv_name="IN2_1",
+    autosave_multiplier=True,  # Automatically save the multiplier to file
+    autosave_offset=True       # Automatically save the offset to file
+)
+
+# You can manipulate the soft scaling PVs directly from Python
+ai4.multiplier.set(1.5)
+print(f"Custom offset: {ai4.offset.get()}")
 
 # Advanced configuration with metadata
 ao1 = RevPiEpics.builder(
@@ -228,9 +238,11 @@ RevPiEpics.start(dispatcher=dispatcher)
 RevPiEpics.init(
     debug=True,        # Enable debug messages
     cycletime=100,     # Update cycle in ms (default: 200ms)
-    auto_prefix=True   # Use PiCtory names for prefixes
-    cleanup=True       # Enable automatic cleanup on exit. 
+    auto_prefix=True,  # Use PiCtory names for prefixes
+    cleanup=True,      # Enable automatic cleanup on exit. 
                        # Resets the default input/output value (PiControl) before exiting
+    autosave=True,     # Enable global state autosave
+    autosave_dir="/tmp", # Directory to store the softsav backup file
 )
 ```
 
@@ -244,15 +256,18 @@ RevPiEpics.init(
 | `EGU` | Engineering units | str | `"°C"`, `"mV"`, `"bar"` |
 | `DRVL` | Low limit (outputs) | float | `0.0` |
 | `DRVH` | High limit (outputs) | float | `100.0` |
+| `autosave_multiplier` | Save AIO multiplier to disk | bool | `True` |
+| `autosave_offset` | Save AIO offset to disk | bool | `True` |
+| `autosave` | Native PV field autosave | bool/list | `True`, `["PREC", "EGU"]` |
 
 ## 🏗️ Architecture
 
 ```
-┌─────────────────┐    ┌──────────────┐    ┌─────────────────┐
-│   Revolution Pi │    │  RevPiEpics  │    │  EPICS Network  │
-│                 │◄──►│              │◄──►│                 │
-│  I/O Modules    │    │  pythonSoftIOC│    │  Client Apps    │
-└─────────────────┘    └──────────────┘    └─────────────────┘
+┌─────────────────┐    ┌────────────────┐    ┌─────────────────┐
+│   Revolution Pi │    │  RevPiEpics    │    │  EPICS Network  │
+│                 │◄──►│                │◄──►│                 │
+│  I/O Modules    │    │  pythonSoftIOC │    │  Client Apps    │
+└─────────────────┘    └────────────────┘    └─────────────────┘
 ```
 
 ## 🔍 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ from softioc import builder
 builder.SetDeviceName("TEST")
 
 # Initialization (debug and cycletime are optional)
-RevPiEpics.init(debug=True, cycletime=200)
+RevPiEpics.init(
+    debug=True, 
+    cycletime=200, 
+    autosave=True, 
+    autosave_dir="/tmp"
+)
 
 # Create PVs with automatic type detection
 ai1 = RevPiEpics.builder("OutputStatus_2_i06")  # PV: TEST:OutputStatus_2_i06
@@ -135,8 +140,18 @@ builder.SetDeviceName("ACCELERATOR")
 # auto_prefix allows using names given to cards by PiCtory
 RevPiEpics.init(debug=True, cycletime=100, auto_prefix=True)
 
-temp_sensor = RevPiEpics.builder("InputValue_1_i06", EGU="°C") 
-pump_speed = RevPiEpics.builder("OutputValue_1_i06", EGU="%", DRVL=0, DRVH=100)
+temp_sensor = RevPiEpics.builder(
+    "InputValue_1_i06", 
+    EGU="°C", 
+    initial_offset=-5.0  # Optional initial offset override
+) 
+pump_speed = RevPiEpics.builder(
+    "OutputValue_1_i06", 
+    EGU="%", 
+    DRVL=0, 
+    DRVH=100,
+    autosave_params=True # Implicitly saves both multiplier and offset
+)
 
 # Using EPICS records
 def temperature_control():
@@ -236,13 +251,15 @@ RevPiEpics.start(dispatcher=dispatcher)
 
 ```python
 RevPiEpics.init(
-    debug=True,        # Enable debug messages
-    cycletime=100,     # Update cycle in ms (default: 200ms)
-    auto_prefix=True,  # Use PiCtory names for prefixes
-    cleanup=True,      # Enable automatic cleanup on exit. 
-                       # Resets the default input/output value (PiControl) before exiting
-    autosave=True,     # Enable global state autosave
+    debug=True,          # Enable debug messages
+    cycletime=100,       # Update cycle in ms (default: 200ms)
+    auto_prefix=True,    # Use PiCtory names for prefixes
+    cleanup=True,        # Enable automatic cleanup on exit. 
+                         # Resets the default input/output value (PiControl) before exiting
+    autosave=True,       # Enable global state autosave
     autosave_dir="/tmp", # Directory to store the softsav backup file
+    autosave_name="my_ioc", # Custom name for the .softsav file
+    autosave_period=10.0 # Autosave frequency in seconds
 )
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,33 +1,34 @@
-# Notes de mise à jour (Release) - RevPiEpics
+# Release Notes - RevPiEpics v0.2.1
 
-## Nouveautés et Améliorations : Architecture, Flexibilité et Autosave
+## What's New: Architecture, Flexibility, and Autosave
 
-### 1. Refonte de l'Architecture Interne (IOMap)
-L'objet monolithique `IOMap` a été refactoré en une hiérarchie orientée objet plus propre. Désormais, les entrées/sorties analogiques utilisent la classe `AnalogIOMap`, ce qui allège l'empreinte mémoire des signaux binaires simples et supprime de nombreuses vérifications conditionnelles redondantes.
+### 1. Internal Architecture Refactoring (IOMap)
+The monolithic `IOMap` object has been refactored into a cleaner object-oriented hierarchy. Analog inputs/outputs now use the `AnalogIOMap` class, which reduces the memory footprint for simple binary signals and removes numerous redundant conditional checks.
 
-### 2. Intégration Native de l'Autosave (softioc.autosave)
-Il est maintenant possible d'activer la sauvegarde automatique des états de configuration EPICS :
-- **Activation Globale :** Dans `RevPiEpics.init(..., autosave=True, autosave_dir="/tmp/save")`.
-- **Contrôle Granulaire :** Lors de la création d'un PV analogique, vous pouvez spécifier `autosave_multiplier=True` ou `autosave_offset=True` pour sauvegarder ces paramètres.
-- Le paramètre natif `autosave=...` pour les variables principales est également supporté de base pour sauvegarder des tableaux (ex: `["PREC", "EGU", "VAL"]`).
+### 2. Native Autosave Integration (softioc.autosave)
+It is now possible to enable automatic backup of EPICS configuration states:
+- **Global Activation:** In `RevPiEpics.init(..., autosave=True, autosave_dir="/tmp/save")`.
+- **Granular Control:** When creating an analog PV, you can specify `autosave_multiplier=True` or `autosave_offset=True` to specifically save these parameters to the `.softsav` file.
+- The standard `autosave=...` parameter for primary variables is fully supported out of the box (e.g., `autosave=["PREC", "EGU", "VAL"]`).
 
-### 3. Simplification des Échelles Logicielles (Float PVs)
-L'ancien comportement qui générait un PV "DIVISEUR" entier a été retiré. Le système s'appuie désormais uniquement sur un `:MULTIPLIER` et un `:OFFSET`. Ces deux PVs sont aujourd'hui exportés en Record Flottant (`aOut`). Ils acceptent donc pleinement les mathématiques décimales (ex: `0.1` au lieu de diviser par `10`) et les valeurs négatives.
+### 3. Simplified Software Scaling (Float PVs)
+The previous behavior that generated an integer "DIVISOR" PV has been safely removed. The system now strictly relies on a `:MULTIPLIER` and an `:OFFSET`. Both PVs are now exported as Floating-point Records (`aOut`). They fully accept standard decimal computations (e.g. `0.1` instead of dividing by `10`) and negative values.
 
-### 4. Flexibilité sur les PVs de Statut
-Les PVs de statut (ex: `...:STATUS`) ne sont plus créés de manière forcée pour chaque I/O analogique. L'IHM gagne en flexibilité : il suffit de déclarer manuellement via `RevPiEpics.builder("InputStatus_1...")` les statuts à exposer sur le réseau.
+### 4. Direct Scaling Parameter Setup
+When building an analog I/O, developers can disregard PiCtory's system hardware defaults and manually inject the soft EPICS startup configuration straight from python:
+`RevPiEpics.builder("IN1", initial_multiplier=1.5, initial_offset=20.0)`
 
-### 5. API Objet Enrichie
-L'objet RecordWrapper retourné par `RevPiEpics.builder(...)` lors du ciblage d'un module analogique embarque dorénavant ses propriétés filles. Vous pouvez ainsi dynamiquement piloter les paramètres internes via Python : `my_sensor.offset.set(10)`.
+### 5. Enriched Object API
+The `RecordWrapper` Python object returned by `RevPiEpics.builder(...)` when targeting an analog module now structurally integrates its child scaling records. You can dynamically drive tracking parameters from Python execution logic: `my_sensor.offset.set(10)`.
 
 ---
 
-## Fonctionnement du Moteur AIO (Rappel)
+## AIO Engine Core Mechanics (Reminder)
 
-### Calcul mathématique déporté (SoftIOC)
-À l'initialisation, le système importe vos paramètres logiciels figurant dans PiCtory pour calquer la base matérielle par défaut (hardware scale). La nouvelle mise à l'échelle demandée s'effectue intégralement par un calcul dynamique via des Soft PV intégrés dans la boucle interne (`pvsync.py`).
+### Delegated Mathematical Computation (SoftIOC)
+At initialization, the system imports the software parameters mapped in PiCtory to establish an absolute factory baseline. The new scalable conversion is managed entirely by live synchronized computations across the soft PV backend (`pvsync.py`).
 
-### Édition temps-réel via EPICS
-Un opérateur peut librement modifier les Soft PVs virtuels générés (comme `caput IN2_1:MULTIPLIER 0.5`) pour ajuster instantanément le comportement :
-* **Lecture (IN)** : Calcul inversé depuis la valeur binaire (brute) à l'aide des paramètres hardware initiaux, puis application en direct de la nouvelle échelle EPICS.
-* **Écriture (OUT)** : Convertit la requête SCADA via l'échelle EPICS, puis réapplique l'échelle matérielle usine pour fournir la configuration binaire exacte exigée par le convertisseur DA.
+### Real-time EPICS Editing
+An operator can freely modify the mapped Soft PVs (like `caput IN2_1:MULTIPLIER 0.5`) to instantly adjust the underlying behavior:
+* **Reading (IN)**: Inverse calculation from the initial raw binary value scaling back to base zero, subsequently layered dynamically beneath the new EPICS ratio.
+* **Writing (OUT)**: Resolves the SCADA request according to the EPICS layer, then translates and applies the factory hardware ratio to pipeline directly to the Digital-to-Analog hardware converter.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,29 @@
+# Notes de mise à jour (Release) - RevPiEpics
+
+## Nouveautés et Améliorations : Intégration avancée de la carte AIO
+
+### 1. Génération automatique de variables (Auto-PV)
+L'appel à `RevPiEpics.builder(...)` pour une entrée ou sortie dynamique de la carte AIO (Analogique et Température) ne se contente plus de créer une seule variable. Il déploie désormais **automatiquement 5 PVs EPICS** associés pour faciliter le pilotage :
+- Le signal principal de mesure (ex: `TEST:IN2_1`)
+- Son statut opérationnel (ex: `TEST:IN2_1:STATUS`)
+- Son échelle multiplicatrice (ex: `TEST:IN2_1:MULTIPLIER`)
+- Son échelle de division (ex: `TEST:IN2_1:DIVISEUR`)
+- Son décalage (ex: `TEST:IN2_1:OFFSET`)
+
+### 2. Calcul mathématique déporté (SoftIOC)
+Le driver noyau RevPi interdisant la réécriture dynamique sur les offsets de configuration en cours d'exécution, la mise à l'échelle pour l'AIO ne dépend plus uniquement de la couche matérielle figée.
+- À l'initialisation, le système importe vos paramètres configurés dans **PiCtory** pour définir la base matérielle par défaut.
+- Ensuite, la mise à l'échelle (Multiplier, Divisor, Offset) s'effectue intégralement par le biais d'un calcul logiciel dynamique intégré à la boucle de synchronisation (`pvsync.py`).
+
+### 3. Édition temps-réel via EPICS
+L'opérateur ou un IHM peuvent librement modifier l'un des Soft PVs virtuels générés (comme `caput TEST:IN2_1:DIVISEUR 100`) pour ajuster instantanément la valeur des signaux en cours d'acquisition ou d'émission. Le moteur Python `RevPiEpics` récupère dynamiquement :
+* **En lecture** : la véritable mesure brute par *back-calcul* à l'aide des paramètres hardware initiaux, puis y applique vos nouvelles échelles logicielles.
+* **En écriture** : désescalade votre signal de commande EPICS selon vos paramètres logiciels, puis applique l'échelle matérielle pour fournir à la carte AIO la grandeur physique numérisée correcte attendue par le Convertisseur Numérique/Analogique.
+
+---
+### Fichiers impactés
+- **`aio.py`** : Refonte de `builder_aio` afin d'implémenter les multi-PVs, ajout de l'analyse des offsets de process image pour isoler les paramètres d'usine originels.
+- **`revpiepics.py`** : La méthode principale du constructeur accepte dorénavant un tableau groupé (List) contenant la structure IOMap éclatée par l'AIO.
+- **`iomap.py`** : Élargissement de la DataClass pour stocker les pointeurs EPICS vers les Soft PV (`pv_divisor`...) et préserver les constantes matérielles extraites (`hw_divisor`...).
+- **`pvsync.py`** : Les routines `_sync_input` et `_sync_output` englobent désormais de formidables algorithmes croisés inversant les signaux dynamiquement en l'espace de quelques millisecondes.
+- **`.gitignore`** : Présence garantie et vérifiée pour isoler les fichiers temporaires.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,29 +1,33 @@
 # Notes de mise à jour (Release) - RevPiEpics
 
-## Nouveautés et Améliorations : Intégration avancée de la carte AIO
+## Nouveautés et Améliorations : Architecture, Flexibilité et Autosave
 
-### 1. Génération automatique de variables (Auto-PV)
-L'appel à `RevPiEpics.builder(...)` pour une entrée ou sortie dynamique de la carte AIO (Analogique et Température) ne se contente plus de créer une seule variable. Il déploie désormais **automatiquement 5 PVs EPICS** associés pour faciliter le pilotage :
-- Le signal principal de mesure (ex: `TEST:IN2_1`)
-- Son statut opérationnel (ex: `TEST:IN2_1:STATUS`)
-- Son échelle multiplicatrice (ex: `TEST:IN2_1:MULTIPLIER`)
-- Son échelle de division (ex: `TEST:IN2_1:DIVISEUR`)
-- Son décalage (ex: `TEST:IN2_1:OFFSET`)
+### 1. Refonte de l'Architecture Interne (IOMap)
+L'objet monolithique `IOMap` a été refactoré en une hiérarchie orientée objet plus propre. Désormais, les entrées/sorties analogiques utilisent la classe `AnalogIOMap`, ce qui allège l'empreinte mémoire des signaux binaires simples et supprime de nombreuses vérifications conditionnelles redondantes.
 
-### 2. Calcul mathématique déporté (SoftIOC)
-Le driver noyau RevPi interdisant la réécriture dynamique sur les offsets de configuration en cours d'exécution, la mise à l'échelle pour l'AIO ne dépend plus uniquement de la couche matérielle figée.
-- À l'initialisation, le système importe vos paramètres configurés dans **PiCtory** pour définir la base matérielle par défaut.
-- Ensuite, la mise à l'échelle (Multiplier, Divisor, Offset) s'effectue intégralement par le biais d'un calcul logiciel dynamique intégré à la boucle de synchronisation (`pvsync.py`).
+### 2. Intégration Native de l'Autosave (softioc.autosave)
+Il est maintenant possible d'activer la sauvegarde automatique des états de configuration EPICS :
+- **Activation Globale :** Dans `RevPiEpics.init(..., autosave=True, autosave_dir="/tmp/save")`.
+- **Contrôle Granulaire :** Lors de la création d'un PV analogique, vous pouvez spécifier `autosave_multiplier=True` ou `autosave_offset=True` pour sauvegarder ces paramètres.
+- Le paramètre natif `autosave=...` pour les variables principales est également supporté de base pour sauvegarder des tableaux (ex: `["PREC", "EGU", "VAL"]`).
 
-### 3. Édition temps-réel via EPICS
-L'opérateur ou un IHM peuvent librement modifier l'un des Soft PVs virtuels générés (comme `caput TEST:IN2_1:DIVISEUR 100`) pour ajuster instantanément la valeur des signaux en cours d'acquisition ou d'émission. Le moteur Python `RevPiEpics` récupère dynamiquement :
-* **En lecture** : la véritable mesure brute par *back-calcul* à l'aide des paramètres hardware initiaux, puis y applique vos nouvelles échelles logicielles.
-* **En écriture** : désescalade votre signal de commande EPICS selon vos paramètres logiciels, puis applique l'échelle matérielle pour fournir à la carte AIO la grandeur physique numérisée correcte attendue par le Convertisseur Numérique/Analogique.
+### 3. Simplification des Échelles Logicielles (Float PVs)
+L'ancien comportement qui générait un PV "DIVISEUR" entier a été retiré. Le système s'appuie désormais uniquement sur un `:MULTIPLIER` et un `:OFFSET`. Ces deux PVs sont aujourd'hui exportés en Record Flottant (`aOut`). Ils acceptent donc pleinement les mathématiques décimales (ex: `0.1` au lieu de diviser par `10`) et les valeurs négatives.
+
+### 4. Flexibilité sur les PVs de Statut
+Les PVs de statut (ex: `...:STATUS`) ne sont plus créés de manière forcée pour chaque I/O analogique. L'IHM gagne en flexibilité : il suffit de déclarer manuellement via `RevPiEpics.builder("InputStatus_1...")` les statuts à exposer sur le réseau.
+
+### 5. API Objet Enrichie
+L'objet RecordWrapper retourné par `RevPiEpics.builder(...)` lors du ciblage d'un module analogique embarque dorénavant ses propriétés filles. Vous pouvez ainsi dynamiquement piloter les paramètres internes via Python : `my_sensor.offset.set(10)`.
 
 ---
-### Fichiers impactés
-- **`aio.py`** : Refonte de `builder_aio` afin d'implémenter les multi-PVs, ajout de l'analyse des offsets de process image pour isoler les paramètres d'usine originels.
-- **`revpiepics.py`** : La méthode principale du constructeur accepte dorénavant un tableau groupé (List) contenant la structure IOMap éclatée par l'AIO.
-- **`iomap.py`** : Élargissement de la DataClass pour stocker les pointeurs EPICS vers les Soft PV (`pv_divisor`...) et préserver les constantes matérielles extraites (`hw_divisor`...).
-- **`pvsync.py`** : Les routines `_sync_input` et `_sync_output` englobent désormais de formidables algorithmes croisés inversant les signaux dynamiquement en l'espace de quelques millisecondes.
-- **`.gitignore`** : Présence garantie et vérifiée pour isoler les fichiers temporaires.
+
+## Fonctionnement du Moteur AIO (Rappel)
+
+### Calcul mathématique déporté (SoftIOC)
+À l'initialisation, le système importe vos paramètres logiciels figurant dans PiCtory pour calquer la base matérielle par défaut (hardware scale). La nouvelle mise à l'échelle demandée s'effectue intégralement par un calcul dynamique via des Soft PV intégrés dans la boucle interne (`pvsync.py`).
+
+### Édition temps-réel via EPICS
+Un opérateur peut librement modifier les Soft PVs virtuels générés (comme `caput IN2_1:MULTIPLIER 0.5`) pour ajuster instantanément le comportement :
+* **Lecture (IN)** : Calcul inversé depuis la valeur binaire (brute) à l'aide des paramètres hardware initiaux, puis application en direct de la nouvelle échelle EPICS.
+* **Écriture (OUT)** : Convertit la requête SCADA via l'échelle EPICS, puis réapplique l'échelle matérielle usine pour fournir la configuration binaire exacte exigée par le convertisseur DA.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "revpiepics"
-version = "0.1.2"
+version = "0.2.0"
 description = "EPICS interface for Revolution Pi IOs"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "revpiepics"
-version = "0.2.0"
+version = "0.2.1"
 description = "EPICS interface for Revolution Pi IOs"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/revpiepics/aio.py
+++ b/revpiepics/aio.py
@@ -27,7 +27,7 @@ from softioc import builder
 
 import logging
 from .recod import RecordDirection, RecordType
-from .iomap import IOMap
+from .iomap import IOMap, AnalogIOMap
 from .utils import status_bit_length, record_write, get_io_offset_value
 
 from revpimodio2.pictory import ProductType, AIO
@@ -98,6 +98,10 @@ def builder_aio(
     # Calculate the relative offset within the AIO module
     parent_offset = io_point._parentdevice._offset
     offset = io_point.address - parent_offset
+    # Extract custom scaling autosave fields, removing them from generic **fields
+    autosave_params = fields.pop('autosave_params', False)
+    autosave_offset = fields.pop('autosave_offset', autosave_params)
+    autosave_multiplier = fields.pop('autosave_multiplier', autosave_params)
     
     # Initialize variables to track the created record and its properties
     record = None
@@ -114,8 +118,17 @@ def builder_aio(
         record_type = RecordType.ANALOG
 
     elif offset in ANALOG_INPUT_STATUS_OFFSETS:
-        logger.error(f"Status PV for '{io_name}' is generated automatically. Please map the main input instead.")
-        return None
+        # Create mbbi record for analog input status
+        record = builder.mbbIn(
+            pv_name,
+            "OK",
+            ("Below the range", "MAJOR"),
+            ("Above the range", "MAJOR"),
+            initial_value=status_bit_length(io_point.value),
+            **fields
+        )
+        record_direction = RecordDirection.INPUT
+        record_type = RecordType.STATUS
 
     # ------------------------------------------------------------------
     # Temperature inputs
@@ -127,15 +140,39 @@ def builder_aio(
         record_type = RecordType.ANALOG
 
     elif offset in TEMPERATURE_INPUT_STATUS_OFFSETS:
-        logger.error(f"Status PV for '{io_name}' is generated automatically. Please map the main input instead.")
-        return None
+        # Create mbbi record for temperature input status
+        record = builder.mbbIn(
+            pv_name,
+            "OK",
+            ("T<-200°C / short circuit", "MAJOR"),
+            ("T>850°C / not connected", "MAJOR"),
+            initial_value=status_bit_length(io_point.value),
+            **fields
+        )
+        record_direction = RecordDirection.INPUT
+        record_type = RecordType.STATUS
 
     # ------------------------------------------------------------------
     # Analog outputs
     # ------------------------------------------------------------------
     elif offset in ANALOG_OUTPUT_STATUS_OFFSETS:
-        logger.error(f"Status PV for '{io_name}' is generated automatically. Please map the main output instead.")
-        return None
+        # Create mbbi record for analog output status
+        record = builder.mbbIn(
+            pv_name,
+            "OK",
+            ("Temperature error", "MAJOR"),
+            ("Open load", "MAJOR"),
+            ("Internal error", "MAJOR"),
+            ("Range error", "MAJOR"),
+            ("Internal purposes", "MAJOR"),
+            ("Supply voltage < 10.2V", "MAJOR"),
+            ("Supply voltage > 28.8V", "MAJOR"),
+            ("Connection timeout", "MAJOR"),
+            initial_value=status_bit_length(io_point.value),
+            **fields
+        )
+        record_direction = RecordDirection.INPUT
+        record_type = RecordType.STATUS
 
     elif offset in ANALOG_OUTPUT_OFFSETS:
         # Create analog output record with proper scaling and range validation
@@ -195,103 +232,67 @@ def builder_aio(
         from .revpiepics import RevPiEpics
         revpi = RevPiEpics.get_mod_io()
 
-        ret_mappings = []
         is_aio_analog = False
         hw_m, hw_d, hw_o = 1.0, 1.0, 0.0
-        pv_m, pv_d, pv_o = None, None, None
+        pv_m, pv_o = None, None
         
         if offset in ANALOG_INPUT_OFFSETS + TEMPERATURE_INPUT_OFFSETS + ANALOG_OUTPUT_OFFSETS:
             is_aio_analog = True
             
             # Extract parameters based on input/output type
             _m, _d, _o = None, None, None
-            status_offset = None
             
             if offset in ANALOG_INPUT_OFFSETS:
                 _m, _d, _o = _read_analog_in_params(offset, parent_offset)
-                status_offset = parent_offset + 8 + ANALOG_INPUT_OFFSETS.index(offset)
             elif offset in TEMPERATURE_INPUT_OFFSETS:
                 _m, _d, _o = _read_temp_in_params(offset, parent_offset)
-                status_offset = parent_offset + 16 + TEMPERATURE_INPUT_OFFSETS.index(offset)
             else: # ANALOG_OUTPUT_OFFSETS
                 # output params returns `_range` as 1st element
                 _range, _m, _d, _o = _read_analog_out_params(offset, parent_offset)
-                status_offset = parent_offset + 18 + ANALOG_OUTPUT_OFFSETS.index(offset)
             
             if _m is not None and _d is not None and _o is not None:
                 hw_m, hw_d, hw_o = float(_m), float(_d), float(_o)
 
-            # Create Soft PVs for parameters
-            pv_m = builder.longOut(f"{pv_name}:MULTIPLIER", initial_value=int(hw_m))
-            pv_d = builder.longOut(f"{pv_name}:DIVISEUR", initial_value=int(hw_d))
-            pv_o = builder.longOut(f"{pv_name}:OFFSET", initial_value=int(hw_o))
-
-            # Create and bind STATUS PV
-            if revpi and revpi.io and status_offset is not None:
-                try:
-                    status_io = revpi.io[status_offset][0]
-                    if offset in ANALOG_INPUT_OFFSETS:
-                        status_record = builder.mbbIn(
-                            f"{pv_name}:STATUS",
-                            "OK",
-                            ("Below the range", "MAJOR"),
-                            ("Above the range", "MAJOR"),
-                            initial_value=status_bit_length(status_io.value)
-                        )
-                    elif offset in TEMPERATURE_INPUT_OFFSETS:
-                        status_record = builder.mbbIn(
-                            f"{pv_name}:STATUS",
-                            "OK",
-                            ("T<-200°C / short circuit", "MAJOR"),
-                            ("T>850°C / not connected", "MAJOR"),
-                            initial_value=status_bit_length(status_io.value)
-                        )
-                    else:
-                        status_record = builder.mbbIn(
-                            f"{pv_name}:STATUS",
-                            "OK",
-                            ("Temperature error", "MAJOR"),
-                            ("Open load", "MAJOR"),
-                            ("Internal error", "MAJOR"),
-                            ("Range error", "MAJOR"),
-                            ("Internal purposes", "MAJOR"),
-                            ("Supply voltage < 10.2V", "MAJOR"),
-                            ("Supply voltage > 28.8V", "MAJOR"),
-                            ("Connection timeout", "MAJOR"),
-                            initial_value=status_bit_length(status_io.value)
-                        )
-                    status_mapping = IOMap(
-                        io_name=status_io.name,
-                        pv_name=f"{pv_name}:STATUS",
-                        io_point=status_io,
-                        record=status_record,
-                        direction=RecordDirection.INPUT,
-                        record_type=RecordType.STATUS
-                    )
-                    ret_mappings.append(status_mapping)
-                except Exception as e:
-                    logger.error(f"Failed to create auto STATUS PV for {pv_name}: {e}")
+            # Create Soft PVs for parameters as Analog (Float)
+            initial_m = float(hw_m) / float(hw_d) if hw_d != 0 else float(hw_m)
+            pv_m = builder.aOut(
+                f"{pv_name}:MULTIPLIER", 
+                initial_value=initial_m,
+                autosave=autosave_multiplier
+            )
+            pv_o = builder.aOut(
+                f"{pv_name}:OFFSET", 
+                initial_value=float(hw_o),
+                autosave=autosave_offset
+            )
 
         # Construct primary mapping
-        main_mapping = IOMap(
-            io_name=io_name,
-            pv_name=pv_name,
-            io_point=io_point,
-            record=record,
-            direction=record_direction,
-            record_type=record_type,
-            is_aio_analog=is_aio_analog,
-            hw_multiplier=hw_m,
-            hw_divisor=hw_d,
-            hw_offset=hw_o,
-            pv_multiplier=pv_m,
-            pv_divisor=pv_d,
-            pv_offset=pv_o
-        )
+        if is_aio_analog:
+            main_mapping = AnalogIOMap(
+                io_name=io_name,
+                pv_name=pv_name,
+                io_point=io_point,
+                record=record,
+                direction=record_direction,
+                record_type=record_type,
+                hw_multiplier=hw_m,
+                hw_divisor=hw_d,
+                hw_offset=hw_o,
+                pv_multiplier=pv_m,
+                pv_offset=pv_o
+            )
+        else:
+            main_mapping = IOMap(
+                io_name=io_name,
+                pv_name=pv_name,
+                io_point=io_point,
+                record=record,
+                direction=record_direction,
+                record_type=record_type
+            )
         
-        # Insert primary record at index 0 so builder returns it
-        ret_mappings.insert(0, main_mapping)
-        return ret_mappings
+        # Return the generated mapping
+        return main_mapping
     else:
         return None
 

--- a/revpiepics/aio.py
+++ b/revpiepics/aio.py
@@ -114,17 +114,8 @@ def builder_aio(
         record_type = RecordType.ANALOG
 
     elif offset in ANALOG_INPUT_STATUS_OFFSETS:
-        # Create multi-bit binary input for analog input status
-        record = builder.mbbIn(
-            pv_name,
-            "OK",                          # State 0: Normal operation
-            ("Below the range", "MAJOR"),  # State 1: Under-range alarm
-            ("Above the range", "MAJOR"),  # State 2: Over-range alarm
-            initial_value=status_bit_length(io_point.value),
-            **fields,
-        )
-        record_direction = RecordDirection.INPUT
-        record_type = RecordType.STATUS
+        logger.error(f"Status PV for '{io_name}' is generated automatically. Please map the main input instead.")
+        return None
 
     # ------------------------------------------------------------------
     # Temperature inputs
@@ -136,39 +127,15 @@ def builder_aio(
         record_type = RecordType.ANALOG
 
     elif offset in TEMPERATURE_INPUT_STATUS_OFFSETS:
-        # Create multi-bit binary input for temperature sensor status
-        record = builder.mbbIn(
-            pv_name,
-            "OK",                                   # State 0: Normal operation
-            ("T<-200°C / short circuit", "MAJOR"),  # State 1: Sensor short circuit
-            ("T>850°C / not connected", "MAJOR"),   # State 2: Sensor disconnected
-            initial_value=status_bit_length(io_point.value),
-            **fields,
-        )
-        record_direction = RecordDirection.INPUT
-        record_type = RecordType.ANALOG
+        logger.error(f"Status PV for '{io_name}' is generated automatically. Please map the main input instead.")
+        return None
 
     # ------------------------------------------------------------------
     # Analog outputs
     # ------------------------------------------------------------------
     elif offset in ANALOG_OUTPUT_STATUS_OFFSETS:
-        # Create multi-bit binary input for analog output status monitoring
-        record = builder.mbbIn(
-            pv_name,
-            "OK",                                   # State 0: Normal operation
-            ("Temperature error", "MAJOR"),         # State 1: Thermal protection
-            ("Open load", "MAJOR"),                 # State 2: Load disconnected
-            ("Internal error", "MAJOR"),            # State 3: Hardware malfunction
-            ("Range error", "MAJOR"),               # State 4: Output value out of range
-            ("Internal purposes", "MAJOR"),         # State 5: Reserved for internal use
-            ("Supply voltage < 10.2V", "MAJOR"),    # State 6: Under-voltage condition
-            ("Supply voltage > 28.8V", "MAJOR"),    # State 7: Over-voltage condition
-            ("Connection timeout", "MAJOR"),        # State 8: Communication timeout
-            initial_value=status_bit_length(io_point.value),
-            **fields,
-        )
-        record_direction = RecordDirection.INPUT
-        record_type = RecordType.STATUS
+        logger.error(f"Status PV for '{io_name}' is generated automatically. Please map the main output instead.")
+        return None
 
     elif offset in ANALOG_OUTPUT_OFFSETS:
         # Create analog output record with proper scaling and range validation
@@ -224,16 +191,107 @@ def builder_aio(
                 logger.error("Analog output '%s' is disabled or has invalid parameters", io_point.name)
     
     # Create and return the IO mapping if record creation was successful
-    if record and record_direction and record_type : 
-        mapping = IOMap(
-                    io_name=io_name,
-                    pv_name=pv_name,
-                    io_point=io_point,
-                    record=record,
-                    direction=record_direction,
-                    record_type=record_type
-                )
-        return mapping
+    if record and record_direction and record_type: 
+        from .revpiepics import RevPiEpics
+        revpi = RevPiEpics.get_mod_io()
+
+        ret_mappings = []
+        is_aio_analog = False
+        hw_m, hw_d, hw_o = 1.0, 1.0, 0.0
+        pv_m, pv_d, pv_o = None, None, None
+        
+        if offset in ANALOG_INPUT_OFFSETS + TEMPERATURE_INPUT_OFFSETS + ANALOG_OUTPUT_OFFSETS:
+            is_aio_analog = True
+            
+            # Extract parameters based on input/output type
+            _m, _d, _o = None, None, None
+            status_offset = None
+            
+            if offset in ANALOG_INPUT_OFFSETS:
+                _m, _d, _o = _read_analog_in_params(offset, parent_offset)
+                status_offset = parent_offset + 8 + ANALOG_INPUT_OFFSETS.index(offset)
+            elif offset in TEMPERATURE_INPUT_OFFSETS:
+                _m, _d, _o = _read_temp_in_params(offset, parent_offset)
+                status_offset = parent_offset + 16 + TEMPERATURE_INPUT_OFFSETS.index(offset)
+            else: # ANALOG_OUTPUT_OFFSETS
+                # output params returns `_range` as 1st element
+                _range, _m, _d, _o = _read_analog_out_params(offset, parent_offset)
+                status_offset = parent_offset + 18 + ANALOG_OUTPUT_OFFSETS.index(offset)
+            
+            if _m is not None and _d is not None and _o is not None:
+                hw_m, hw_d, hw_o = float(_m), float(_d), float(_o)
+
+            # Create Soft PVs for parameters
+            pv_m = builder.longOut(f"{pv_name}:MULTIPLIER", initial_value=int(hw_m))
+            pv_d = builder.longOut(f"{pv_name}:DIVISEUR", initial_value=int(hw_d))
+            pv_o = builder.longOut(f"{pv_name}:OFFSET", initial_value=int(hw_o))
+
+            # Create and bind STATUS PV
+            if revpi and revpi.io and status_offset is not None:
+                try:
+                    status_io = revpi.io[status_offset][0]
+                    if offset in ANALOG_INPUT_OFFSETS:
+                        status_record = builder.mbbIn(
+                            f"{pv_name}:STATUS",
+                            "OK",
+                            ("Below the range", "MAJOR"),
+                            ("Above the range", "MAJOR"),
+                            initial_value=status_bit_length(status_io.value)
+                        )
+                    elif offset in TEMPERATURE_INPUT_OFFSETS:
+                        status_record = builder.mbbIn(
+                            f"{pv_name}:STATUS",
+                            "OK",
+                            ("T<-200°C / short circuit", "MAJOR"),
+                            ("T>850°C / not connected", "MAJOR"),
+                            initial_value=status_bit_length(status_io.value)
+                        )
+                    else:
+                        status_record = builder.mbbIn(
+                            f"{pv_name}:STATUS",
+                            "OK",
+                            ("Temperature error", "MAJOR"),
+                            ("Open load", "MAJOR"),
+                            ("Internal error", "MAJOR"),
+                            ("Range error", "MAJOR"),
+                            ("Internal purposes", "MAJOR"),
+                            ("Supply voltage < 10.2V", "MAJOR"),
+                            ("Supply voltage > 28.8V", "MAJOR"),
+                            ("Connection timeout", "MAJOR"),
+                            initial_value=status_bit_length(status_io.value)
+                        )
+                    status_mapping = IOMap(
+                        io_name=status_io.name,
+                        pv_name=f"{pv_name}:STATUS",
+                        io_point=status_io,
+                        record=status_record,
+                        direction=RecordDirection.INPUT,
+                        record_type=RecordType.STATUS
+                    )
+                    ret_mappings.append(status_mapping)
+                except Exception as e:
+                    logger.error(f"Failed to create auto STATUS PV for {pv_name}: {e}")
+
+        # Construct primary mapping
+        main_mapping = IOMap(
+            io_name=io_name,
+            pv_name=pv_name,
+            io_point=io_point,
+            record=record,
+            direction=record_direction,
+            record_type=record_type,
+            is_aio_analog=is_aio_analog,
+            hw_multiplier=hw_m,
+            hw_divisor=hw_d,
+            hw_offset=hw_o,
+            pv_multiplier=pv_m,
+            pv_divisor=pv_d,
+            pv_offset=pv_o
+        )
+        
+        # Insert primary record at index 0 so builder returns it
+        ret_mappings.insert(0, main_mapping)
+        return ret_mappings
     else:
         return None
 
@@ -353,6 +411,48 @@ def _read_analog_out_params(offset: int, parent_offset: int) -> Tuple[int | None
     # Read the actual parameter values from the process image
     return (
         get_io_offset_value(parent_offset + map_entry['range']),
+        get_io_offset_value(parent_offset + map_entry['multiplier']),
+        get_io_offset_value(parent_offset + map_entry['divisor']),
+        get_io_offset_value(parent_offset + map_entry['offset']),
+    )
+
+def _read_analog_in_params(offset: int, parent_offset: int) -> Tuple[int | None, int | None, int | None]:
+    """
+    Read multiplier, divisor, and offset parameters for a given analog input channel.
+    """
+    offset_map = {
+        0: {'multiplier': 33, 'divisor': 35, 'offset': 37},
+        2: {'multiplier': 43, 'divisor': 45, 'offset': 47},
+        4: {'multiplier': 53, 'divisor': 55, 'offset': 57},
+        6: {'multiplier': 63, 'divisor': 65, 'offset': 67},
+    }
+    
+    map_entry = offset_map.get(offset)
+    if not map_entry:
+        logger.error("Unknown analog input offset: %s", offset)
+        return None, None, None
+
+    return (
+        get_io_offset_value(parent_offset + map_entry['multiplier']),
+        get_io_offset_value(parent_offset + map_entry['divisor']),
+        get_io_offset_value(parent_offset + map_entry['offset']),
+    )
+
+def _read_temp_in_params(offset: int, parent_offset: int) -> Tuple[int | None, int | None, int | None]:
+    """
+    Read multiplier, divisor, and offset parameters for a given temperature input channel.
+    """
+    offset_map = {
+        12: {'multiplier': 93, 'divisor': 95, 'offset': 97},
+        14: {'multiplier': 103, 'divisor': 105, 'offset': 107},
+    }
+    
+    map_entry = offset_map.get(offset)
+    if not map_entry:
+        logger.error("Unknown temperature input offset: %s", offset)
+        return None, None, None
+
+    return (
         get_io_offset_value(parent_offset + map_entry['multiplier']),
         get_io_offset_value(parent_offset + map_entry['divisor']),
         get_io_offset_value(parent_offset + map_entry['offset']),

--- a/revpiepics/aio.py
+++ b/revpiepics/aio.py
@@ -421,10 +421,10 @@ def _read_analog_in_params(offset: int, parent_offset: int) -> Tuple[int | None,
     Read multiplier, divisor, and offset parameters for a given analog input channel.
     """
     offset_map = {
-        0: {'multiplier': 33, 'divisor': 35, 'offset': 37},
-        2: {'multiplier': 43, 'divisor': 45, 'offset': 47},
-        4: {'multiplier': 53, 'divisor': 55, 'offset': 57},
-        6: {'multiplier': 63, 'divisor': 65, 'offset': 67},
+        0: {'multiplier': 25, 'divisor': 27, 'offset': 29},
+        2: {'multiplier': 32, 'divisor': 34, 'offset': 36},
+        4: {'multiplier': 39, 'divisor': 41, 'offset': 43},
+        6: {'multiplier': 46, 'divisor': 48, 'offset': 50},
     }
     
     map_entry = offset_map.get(offset)
@@ -443,8 +443,8 @@ def _read_temp_in_params(offset: int, parent_offset: int) -> Tuple[int | None, i
     Read multiplier, divisor, and offset parameters for a given temperature input channel.
     """
     offset_map = {
-        12: {'multiplier': 93, 'divisor': 95, 'offset': 97},
-        14: {'multiplier': 103, 'divisor': 105, 'offset': 107},
+        12: {'multiplier': 55, 'divisor': 57, 'offset': 59},
+        14: {'multiplier': 63, 'divisor': 65, 'offset': 67},
     }
     
     map_entry = offset_map.get(offset)

--- a/revpiepics/aio.py
+++ b/revpiepics/aio.py
@@ -103,6 +103,10 @@ def builder_aio(
     autosave_offset = fields.pop('autosave_offset', autosave_params)
     autosave_multiplier = fields.pop('autosave_multiplier', autosave_params)
     
+    # Extract custom initial scaling values
+    initial_multiplier_override = fields.pop('initial_multiplier', None)
+    initial_offset_override = fields.pop('initial_offset', None)
+    
     # Initialize variables to track the created record and its properties
     record = None
     record_direction = None
@@ -255,14 +259,22 @@ def builder_aio(
 
             # Create Soft PVs for parameters as Analog (Float)
             initial_m = float(hw_m) / float(hw_d) if hw_d != 0 else float(hw_m)
+            if initial_multiplier_override is not None:
+                initial_m = float(initial_multiplier_override)
+                
             pv_m = builder.aOut(
                 f"{pv_name}:MULTIPLIER", 
                 initial_value=initial_m,
                 autosave=autosave_multiplier
             )
+            
+            initial_o = float(hw_o)
+            if initial_offset_override is not None:
+                initial_o = float(initial_offset_override)
+                
             pv_o = builder.aOut(
                 f"{pv_name}:OFFSET", 
-                initial_value=float(hw_o),
+                initial_value=initial_o,
                 autosave=autosave_offset
             )
 

--- a/revpiepics/aio.py
+++ b/revpiepics/aio.py
@@ -105,7 +105,20 @@ def builder_aio(
     
     # Extract custom initial scaling values
     initial_multiplier_override = fields.pop('initial_multiplier', None)
+    if initial_multiplier_override is not None:
+        try:
+            initial_multiplier_override = float(initial_multiplier_override)
+        except (ValueError, TypeError):
+            logger.error(f"Invalid initial_multiplier '{initial_multiplier_override}' for '{io_name}', must be numeric. Ignoring.")
+            initial_multiplier_override = None
+
     initial_offset_override = fields.pop('initial_offset', None)
+    if initial_offset_override is not None:
+        try:
+            initial_offset_override = float(initial_offset_override)
+        except (ValueError, TypeError):
+            logger.error(f"Invalid initial_offset '{initial_offset_override}' for '{io_name}', must be numeric. Ignoring.")
+            initial_offset_override = None
     
     # Initialize variables to track the created record and its properties
     record = None

--- a/revpiepics/iomap.py
+++ b/revpiepics/iomap.py
@@ -29,6 +29,9 @@ class IOMap:
         update_record: Flag indicating if record needs update from PV
         last_io_value: Cached last known I/O value for change detection
         last_pv_value: Cached last known PV value for change detection
+        is_aio_analog: Flag to apply soft computation for AIO
+        hw_multiplier: Hardware scaling multiplier read from process image
+        pv_multiplier: Pointer to the EPICS Record wrapper managing multiplier
     """
     # Core mapping configuration
     io_name: str                   # RevPi I/O point identifier
@@ -42,6 +45,16 @@ class IOMap:
     update_record: bool = False                   # Flag for pending record updates
     last_io_value: Optional[Any] = None           # Cached I/O value for change detection
     last_pv_value: Optional[Any] = None           # Cached PV value for change detection
+    
+    # SoftIOC scaling and conversion parameters for AIO
+    is_aio_analog: bool = False                   # Flag for AI/AO soft scaling
+    hw_multiplier: float = 1.0                    # Hardware multiplier constant
+    hw_divisor: float = 1.0                       # Hardware divisor constant
+    hw_offset: float = 0.0                        # Hardware offset constant
+    
+    pv_multiplier: Optional['RecordWrapper'] = None   # EPICS PV for variable multiplier
+    pv_divisor: Optional['RecordWrapper'] = None      # EPICS PV for variable divisor
+    pv_offset: Optional['RecordWrapper'] = None       # EPICS PV for variable offset
 
     def __post_init__(self):
         """

--- a/revpiepics/iomap.py
+++ b/revpiepics/iomap.py
@@ -46,16 +46,6 @@ class IOMap:
     last_io_value: Optional[Any] = None           # Cached I/O value for change detection
     last_pv_value: Optional[Any] = None           # Cached PV value for change detection
     
-    # SoftIOC scaling and conversion parameters for AIO
-    is_aio_analog: bool = False                   # Flag for AI/AO soft scaling
-    hw_multiplier: float = 1.0                    # Hardware multiplier constant
-    hw_divisor: float = 1.0                       # Hardware divisor constant
-    hw_offset: float = 0.0                        # Hardware offset constant
-    
-    pv_multiplier: Optional['RecordWrapper'] = None   # EPICS PV for variable multiplier
-    pv_divisor: Optional['RecordWrapper'] = None      # EPICS PV for variable divisor
-    pv_offset: Optional['RecordWrapper'] = None       # EPICS PV for variable offset
-
     def __post_init__(self):
         """
         Initialize cache values after dataclass construction.
@@ -89,6 +79,32 @@ class IOMap:
             IntIO: The RevPi I/O point for hardware access
         """
         return self.io_point
+
+@dataclass
+class AnalogIOMap(IOMap):
+    """
+    Mapping specialized for Analog I/O points (AIO).
+    
+    Includes hardware scaling constants and EPICS soft scaling parameters.
+    """
+    # SoftIOC scaling and conversion parameters for AIO
+    hw_multiplier: float = 1.0                    # Hardware multiplier constant
+    hw_divisor: float = 1.0                       # Hardware divisor constant
+    hw_offset: float = 0.0                        # Hardware offset constant
+    
+    pv_multiplier: Optional['RecordWrapper'] = None   # EPICS PV for variable multiplier (float)
+    pv_offset: Optional['RecordWrapper'] = None       # EPICS PV for variable offset (float)
+
+    last_pv_multiplier: Optional[float] = None        # Cached multiplier for change detection
+    last_pv_offset: Optional[float] = None            # Cached offset for change detection
+
+    def __post_init__(self):
+        super().__post_init__()
+        try:
+            self.last_pv_multiplier = self.pv_multiplier.get() if self.pv_multiplier else 1.0
+            self.last_pv_offset = self.pv_offset.get() if self.pv_offset else 0.0
+        except Exception as e:
+            logger.warning("Erreur lors de l'initialisation du cache analogique pour %s: %s", self.io_name, e)
 
 @dataclass
 class DicIOMap:

--- a/revpiepics/pvsync.py
+++ b/revpiepics/pvsync.py
@@ -135,6 +135,23 @@ class PVSyncThread(Thread):
         if mapping.update_record:
             # EPICS PV was updated - propagate to RevPi I/O
             pv_value = mapping.record.get()
+            
+            # Apply soft scaling for AIO analog outputs
+            if getattr(mapping, 'is_aio_analog', False):
+                pv_m = mapping.pv_multiplier.get() if mapping.pv_multiplier else 1.0
+                pv_d = mapping.pv_divisor.get() if mapping.pv_divisor else 1.0
+                pv_o = mapping.pv_offset.get() if mapping.pv_offset else 0.0
+                
+                # Back-calculate raw ADC from EPICS PV value
+                if pv_m != 0:
+                    raw_adc = (pv_value - pv_o) * pv_d / pv_m
+                else:
+                    raw_adc = pv_value
+                    
+                # Re-apply hardware constants to write to RevPi process image
+                if mapping.hw_divisor != 0:
+                    pv_value = (raw_adc * mapping.hw_multiplier) / mapping.hw_divisor + mapping.hw_offset
+            
             # Round float values to avoid precision issues
             pv_value = round(pv_value) if isinstance(pv_value, float) else pv_value
 
@@ -151,6 +168,23 @@ class PVSyncThread(Thread):
             # Provide feedback - read actual I/O state back to PV
             io_value = mapping.io_point.value
             pv_value = mapping.record.get()
+            
+            # Apply soft scaling backward for feedback
+            if getattr(mapping, 'is_aio_analog', False):
+                pv_m = mapping.pv_multiplier.get() if mapping.pv_multiplier else 1.0
+                pv_d = mapping.pv_divisor.get() if mapping.pv_divisor else 1.0
+                pv_o = mapping.pv_offset.get() if mapping.pv_offset else 0.0
+                
+                # Back-calculate raw ADC from hardware value
+                if mapping.hw_multiplier != 0:
+                    raw_adc = (io_value - mapping.hw_offset) * mapping.hw_divisor / mapping.hw_multiplier
+                else:
+                    raw_adc = io_value
+                    
+                # Setup theoretical PV value feedback based on soft setting
+                if pv_d != 0:
+                    io_value = (raw_adc * pv_m) / pv_d + pv_o
+            
             pv_value = round(pv_value) if isinstance(pv_value, float) else pv_value
 
             # Update PV if I/O value differs (without processing to avoid loops)
@@ -178,9 +212,25 @@ class PVSyncThread(Thread):
         # Handle different EPICS record types
         if mapping.record_type == RecordType.ANALOG:
             # Direct analog value transfer
-            if mapping.record.get() != io_value:
-                mapping.record.set(io_value)
-                logger.debug("INPUT: IO %s → PV %s = %s", mapping.io_name, mapping.pv_name, io_value)
+            computed_value = io_value
+            if getattr(mapping, 'is_aio_analog', False):
+                pv_m = mapping.pv_multiplier.get() if mapping.pv_multiplier else 1.0
+                pv_d = mapping.pv_divisor.get() if mapping.pv_divisor else 1.0
+                pv_o = mapping.pv_offset.get() if mapping.pv_offset else 0.0
+
+                # Back-calculate raw ADC from hardware value
+                if mapping.hw_multiplier != 0:
+                    raw_adc = (io_value - mapping.hw_offset) * mapping.hw_divisor / mapping.hw_multiplier
+                else:
+                    raw_adc = io_value
+                    
+                # Apply EPICS soft constants
+                if pv_d != 0:
+                    computed_value = (raw_adc * pv_m) / pv_d + pv_o
+                
+            if mapping.record.get() != computed_value:
+                mapping.record.set(computed_value)
+                logger.debug("INPUT: IO %s → PV %s = %s", mapping.io_name, mapping.pv_name, computed_value)
 
         elif mapping.record_type == RecordType.STATUS:
             # Convert to status bit representation

--- a/revpiepics/pvsync.py
+++ b/revpiepics/pvsync.py
@@ -1,7 +1,7 @@
 import logging
 from .recod import RecordDirection, RecordType
 from .utils import status_bit_length
-from .iomap import IOMap
+from .iomap import IOMap, AnalogIOMap
 from threading import Event, Thread
 from timeit import default_timer
 
@@ -138,14 +138,13 @@ class PVSyncThread(Thread):
             pv_value = mapping.record.get()
             
             # Apply soft scaling for AIO analog outputs
-            if getattr(mapping, 'is_aio_analog', False):
+            if isinstance(mapping, AnalogIOMap):
                 pv_m = mapping.pv_multiplier.get() if mapping.pv_multiplier else 1.0
-                pv_d = mapping.pv_divisor.get() if mapping.pv_divisor else 1.0
                 pv_o = mapping.pv_offset.get() if mapping.pv_offset else 0.0
                 
                 # Back-calculate raw ADC from EPICS PV value
                 if pv_m != 0:
-                    raw_adc = (pv_value - pv_o) * pv_d / pv_m
+                    raw_adc = (pv_value - pv_o) / pv_m
                 else:
                     raw_adc = pv_value
                     
@@ -171,9 +170,8 @@ class PVSyncThread(Thread):
             pv_value = mapping.record.get()
             
             # Apply soft scaling backward for feedback
-            if getattr(mapping, 'is_aio_analog', False):
+            if isinstance(mapping, AnalogIOMap):
                 pv_m = mapping.pv_multiplier.get() if mapping.pv_multiplier else 1.0
-                pv_d = mapping.pv_divisor.get() if mapping.pv_divisor else 1.0
                 pv_o = mapping.pv_offset.get() if mapping.pv_offset else 0.0
                 
                 # Back-calculate raw ADC from hardware value
@@ -183,8 +181,7 @@ class PVSyncThread(Thread):
                     raw_adc = io_value
                     
                 # Setup theoretical PV value feedback based on soft setting
-                if pv_d != 0:
-                    io_value = (raw_adc * pv_m) / pv_d + pv_o
+                io_value = (raw_adc * pv_m) + pv_o
             
             pv_value = round(pv_value) if isinstance(pv_value, float) else pv_value
 
@@ -205,20 +202,28 @@ class PVSyncThread(Thread):
             mapping: IOMap instance containing the mapping configuration
         """
         io_value = mapping.io_point.value
+        is_aio_analog = isinstance(mapping, AnalogIOMap)
 
-        # Optimization: skip processing if value hasn't changed
-        if io_value == mapping.last_io_value:
-            return
+        pv_m, pv_o = 1.0, 0.0
+        if is_aio_analog:
+            pv_m = mapping.pv_multiplier.get() if mapping.pv_multiplier else 1.0
+            pv_o = mapping.pv_offset.get() if mapping.pv_offset else 0.0
+            
+            # Optimization: skip processing if neither IO value nor scaling params changed
+            if (io_value == mapping.last_io_value and
+                pv_m == mapping.last_pv_multiplier and
+                pv_o == mapping.last_pv_offset):
+                return
+        else:
+            # Optimization: skip processing if value hasn't changed
+            if io_value == mapping.last_io_value:
+                return
 
         # Handle different EPICS record types
         if mapping.record_type == RecordType.ANALOG:
             # Direct analog value transfer
             computed_value = io_value
-            if getattr(mapping, 'is_aio_analog', False):
-                pv_m = mapping.pv_multiplier.get() if mapping.pv_multiplier else 1.0
-                pv_d = mapping.pv_divisor.get() if mapping.pv_divisor else 1.0
-                pv_o = mapping.pv_offset.get() if mapping.pv_offset else 0.0
-
+            if is_aio_analog:
                 # Back-calculate raw ADC from hardware value
                 if mapping.hw_multiplier != 0:
                     raw_adc = (io_value - mapping.hw_offset) * mapping.hw_divisor / mapping.hw_multiplier
@@ -226,8 +231,7 @@ class PVSyncThread(Thread):
                     raw_adc = io_value
                     
                 # Apply EPICS soft constants
-                if pv_d != 0:
-                    computed_value = (raw_adc * pv_m) / pv_d + pv_o
+                computed_value = (raw_adc * pv_m) + pv_o
                 
             if mapping.record.get() != computed_value:
                 mapping.record.set(computed_value)
@@ -247,8 +251,11 @@ class PVSyncThread(Thread):
                 mapping.record.set(binary_value)
                 logger.debug("INPUT: IO %s → PV %s = %s", mapping.io_name, mapping.pv_name, binary_value)
 
-        # Update last known value for optimization
+        # Update last known values for optimization
         mapping.last_io_value = io_value
+        if is_aio_analog:
+            mapping.last_pv_multiplier = pv_m
+            mapping.last_pv_offset = pv_o
     
     def _sync_cleanup(self) -> None:
         """

--- a/revpiepics/pvsync.py
+++ b/revpiepics/pvsync.py
@@ -44,6 +44,7 @@ class PVSyncThread(Thread):
         Continuously synchronizes I/O data between RevPi and EPICS at the
         specified cycle time. Handles timing control and error recovery.
         """
+        self._stop_event.clear()  # Clear any previous stop signal
         logger.info("Synchronization thread started (cycle: %s ms)", self._cycle_time_ms)
         cycle_time_s = self._cycle_time_ms / 1000.0  # Convert to seconds for timing
 

--- a/revpiepics/revpiepics.py
+++ b/revpiepics/revpiepics.py
@@ -256,9 +256,9 @@ class RevPiEpics:
                     
                     record = mapping[0].get_record()
                     if hasattr(mapping[0], 'pv_multiplier') and mapping[0].pv_multiplier is not None:
-                        record.multiplier = mapping[0].pv_multiplier
+                        object.__setattr__(record, 'multiplier', mapping[0].pv_multiplier)
                     if hasattr(mapping[0], 'pv_offset') and mapping[0].pv_offset is not None:
-                        record.offset = mapping[0].pv_offset
+                        object.__setattr__(record, 'offset', mapping[0].pv_offset)
                     return record
                 else:
                     cls._dictmap.add(mapping)
@@ -266,9 +266,9 @@ class RevPiEpics:
                     
                     record = mapping.get_record()
                     if hasattr(mapping, 'pv_multiplier') and mapping.pv_multiplier is not None:
-                        record.multiplier = mapping.pv_multiplier
+                        object.__setattr__(record, 'multiplier', mapping.pv_multiplier)
                     if hasattr(mapping, 'pv_offset') and mapping.pv_offset is not None:
-                        record.offset = mapping.pv_offset
+                        object.__setattr__(record, 'offset', mapping.pv_offset)
                     return record
             else:
                 return None

--- a/revpiepics/revpiepics.py
+++ b/revpiepics/revpiepics.py
@@ -241,8 +241,11 @@ class RevPiEpics:
                 au_p = fields.pop('autosave_params', False)
                 au_m = fields.pop('autosave_multiplier', False)
                 au_o = fields.pop('autosave_offset', False)
-                if any([au_p, au_m, au_o]):
-                    logger.warning(f"autosave_multiplier/offset is only applicable for Analog endpoints (ignored for '{io_name}')")
+                init_m = fields.pop('initial_multiplier', None)
+                init_o = fields.pop('initial_offset', None)
+                
+                if au_p or au_m or au_o or init_m is not None or init_o is not None:
+                    logger.warning(f"Soft scaling parameters are only applicable to Analog endpoints (ignored for '{io_name}')")
 
             # Use I/O name as PV name if not specified
             if pv_name is None:
@@ -256,8 +259,8 @@ class RevPiEpics:
                 au_o = fields.get('autosave_offset', False)
                 if any([au_base, au_p, au_m, au_o]):
                     logger.warning(
-                        f"L'option autosave=False dans RevPiEpics.init(), "
-                        f"les paramètres autosave pour le PV '{pv_name}' ne seront pas pris en compte."
+                        f"Autosave is disabled in RevPiEpics.init(), "
+                        f"autosave parameters for PV '{pv_name}' will be ignored."
                     )
 
             # Build with or without automatic prefixing

--- a/revpiepics/revpiepics.py
+++ b/revpiepics/revpiepics.py
@@ -24,6 +24,33 @@ from epicsdbbuilder.recordnames import SimpleRecordNames
 
 logger = logging.getLogger(__name__)
 
+class ColorLogFormatter(logging.Formatter):
+    """Custom format logger bringing colors to the console."""
+    
+    COLORS = {
+        logging.DEBUG: "\033[36m",     # Cyan
+        logging.INFO: "\033[33m",      # Yellow
+        logging.WARNING: "\033[35m",   # Magenta
+        logging.ERROR: "\033[31m",     # Red
+        logging.CRITICAL: "\033[1;31m" # Bold Red
+    }
+    RESET = "\033[0m"
+
+    def __init__(self, debug: bool):
+        super().__init__()
+        fmt = (
+            "%(asctime)s [{COLOR}%(levelname)s{RESET}] %(name)s: %(message)s"
+            if debug else "[{COLOR}%(levelname)s{RESET}]: %(message)s"
+        )
+        self.formats = {
+            level: logging.Formatter(fmt.format(COLOR=color, RESET=self.RESET))
+            for level, color in self.COLORS.items()
+        }
+        self.default_fmt = logging.Formatter(fmt.format(COLOR="", RESET=""))
+        
+    def format(self, record):
+        return self.formats.get(record.levelno, self.default_fmt).format(record)
+
 class RevPiEpics:
     """Bridge between RevPi and EPICS with bidirectional synchronization.
     
@@ -129,11 +156,18 @@ class RevPiEpics:
 
                 # Configure logging based on debug mode
                 log_level = logging.DEBUG if debug else logging.INFO
-                log_format = (
-                    "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-                    if debug else "[%(levelname)s]: %(message)s"
-                )
-                logging.basicConfig(level=log_level, format=log_format)
+                
+                # Setup base root logger
+                root_logger = logging.getLogger()
+                root_logger.setLevel(log_level)
+                
+                # Clear all existing handlers if re-initializing
+                if root_logger.hasHandlers():
+                    root_logger.handlers.clear()
+                    
+                ch = logging.StreamHandler()
+                ch.setFormatter(ColorLogFormatter(debug=debug))
+                root_logger.addHandler(ch)
 
                 # Initialize PV synchronization thread
                 cls._pv_sync = PVSyncThread(cls)
@@ -334,7 +368,7 @@ class RevPiEpics:
                     )
                     logger.debug(f"Autosave enabled in {cls._autosave_dir}")
                 else:
-                    logger.warning("Autosave est activé (autosave=True) mais 'autosave_dir' est manquant ! La sauvegarde ne démarrera pas.")
+                    logger.warning("Autosave is enabled (autosave=True) but 'autosave_dir' is missing! The backup will not start.")
 
             # Load EPICS database with all created PVs
             builder.LoadDatabase()

--- a/revpiepics/revpiepics.py
+++ b/revpiepics/revpiepics.py
@@ -212,9 +212,15 @@ class RevPiEpics:
 
             # Add mapping to dictionary and return record wrapper
             if mapping:
-                cls._dictmap.add(mapping)
-                logger.debug(f"PV '{pv_name}' created for I/O '{io_name}'")
-                return mapping.get_record()
+                if isinstance(mapping, list):
+                    for m in mapping:
+                        cls._dictmap.add(m)
+                    logger.debug(f"Multiple PVs created for I/O '{io_name}' starting with '{pv_name}'")
+                    return mapping[0].get_record()
+                else:
+                    cls._dictmap.add(mapping)
+                    logger.debug(f"PV '{pv_name}' created for I/O '{io_name}'")
+                    return mapping.get_record()
             else:
                 return None
 

--- a/revpiepics/revpiepics.py
+++ b/revpiepics/revpiepics.py
@@ -39,14 +39,14 @@ class ColorLogFormatter(logging.Formatter):
     def __init__(self, debug: bool):
         super().__init__()
         fmt = (
-            "%(asctime)s [{COLOR}%(levelname)s{RESET}] %(name)s: %(message)s"
+            "[{COLOR}%(levelname)s{RESET}] %(asctime)s %(name)s: %(message)s"
             if debug else "[{COLOR}%(levelname)s{RESET}]: %(message)s"
         )
         self.formats = {
-            level: logging.Formatter(fmt.format(COLOR=color, RESET=self.RESET))
+            level: logging.Formatter(fmt.format(COLOR=color, RESET=self.RESET), datefmt="%Y-%m-%d %H:%M:%S")
             for level, color in self.COLORS.items()
         }
-        self.default_fmt = logging.Formatter(fmt.format(COLOR="", RESET=""))
+        self.default_fmt = logging.Formatter(fmt.format(COLOR="", RESET=""), datefmt="%Y-%m-%d %H:%M:%S")
         
     def format(self, record):
         return self.formats.get(record.levelno, self.default_fmt).format(record)

--- a/revpiepics/revpiepics.py
+++ b/revpiepics/revpiepics.py
@@ -18,7 +18,7 @@ from .pvsync import PVSyncThread
 from .iomap import DicIOMap, IOMap
 
 import revpimodio2
-from softioc import builder, pythonSoftIoc, softioc
+from softioc import builder, pythonSoftIoc, softioc, autosave
 from softioc.asyncio_dispatcher import AsyncioDispatcher
 from epicsdbbuilder.recordnames import SimpleRecordNames
 
@@ -45,6 +45,11 @@ class RevPiEpics:
     _auto_prefix = False
     # Cycle time in milliseconds
     _cycle_time_ms = None
+    # Autosave configuration
+    _autosave: bool = False
+    _autosave_dir: Optional[str] = None
+    _autosave_name: str = "revpiepics"
+    _autosave_period: float = 30.0
     # PV synchronization thread
     _pv_sync: Optional["PVSyncThread"] = None
     # Thread synchronization lock
@@ -75,7 +80,11 @@ class RevPiEpics:
             cycletime: Optional[int] = 200,
             debug: bool = False,
             cleanup: bool = True,
-            auto_prefix: bool = False
+            auto_prefix: bool = False,
+            autosave: bool = False,
+            autosave_dir: Optional[str] = None,
+            autosave_name: str = "revpiepics",
+            autosave_period: float = 30.0
     ) -> None:
         """Initialize the RevPi-EPICS bridge.
 
@@ -87,6 +96,10 @@ class RevPiEpics:
             debug: Enable debug mode with verbose logging
             cleanup: Enable automatic cleanup on exit
             auto_prefix: Enable automatic PV prefixing based on device hierarchy
+            autosave: Global flag to enable or disable the autosave functionality
+            autosave_dir: Directory to save soft PV configuration (e.g. for scaling parameters)
+            autosave_name: Name of the generated autosave file
+            autosave_period: How frequently (in seconds) the autosave file is recorded
             
         Raises:
             RevPiEpicsInitError: If initialization fails
@@ -109,6 +122,10 @@ class RevPiEpics:
 
                 cls._cleanup = cleanup
                 cls._auto_prefix = auto_prefix
+                cls._autosave = autosave
+                cls._autosave_dir = autosave_dir
+                cls._autosave_name = autosave_name
+                cls._autosave_period = autosave_period
 
                 # Configure logging based on debug mode
                 log_level = logging.DEBUG if debug else logging.INFO
@@ -185,9 +202,29 @@ class RevPiEpics:
                     f"No builder for product type {product_type}"
                 )
 
+            # Warn if user provided scaling autosave to non-AIO module
+            if product_type != revpimodio2.pictory.ProductType.AIO:
+                au_p = fields.pop('autosave_params', False)
+                au_m = fields.pop('autosave_multiplier', False)
+                au_o = fields.pop('autosave_offset', False)
+                if any([au_p, au_m, au_o]):
+                    logger.warning(f"autosave_multiplier/offset is only applicable for Analog endpoints (ignored for '{io_name}')")
+
             # Use I/O name as PV name if not specified
             if pv_name is None:
                 pv_name = io_name
+
+            # Warn if user provided any autosave config while autosave is disabled globally
+            if not cls._autosave:
+                au_base = fields.get('autosave', False)
+                au_p = fields.get('autosave_params', False)
+                au_m = fields.get('autosave_multiplier', False)
+                au_o = fields.get('autosave_offset', False)
+                if any([au_base, au_p, au_m, au_o]):
+                    logger.warning(
+                        f"L'option autosave=False dans RevPiEpics.init(), "
+                        f"les paramètres autosave pour le PV '{pv_name}' ne seront pas pris en compte."
+                    )
 
             # Build with or without automatic prefixing
             if cls._auto_prefix:
@@ -216,11 +253,23 @@ class RevPiEpics:
                     for m in mapping:
                         cls._dictmap.add(m)
                     logger.debug(f"Multiple PVs created for I/O '{io_name}' starting with '{pv_name}'")
-                    return mapping[0].get_record()
+                    
+                    record = mapping[0].get_record()
+                    if hasattr(mapping[0], 'pv_multiplier') and mapping[0].pv_multiplier is not None:
+                        record.multiplier = mapping[0].pv_multiplier
+                    if hasattr(mapping[0], 'pv_offset') and mapping[0].pv_offset is not None:
+                        record.offset = mapping[0].pv_offset
+                    return record
                 else:
                     cls._dictmap.add(mapping)
                     logger.debug(f"PV '{pv_name}' created for I/O '{io_name}'")
-                    return mapping.get_record()
+                    
+                    record = mapping.get_record()
+                    if hasattr(mapping, 'pv_multiplier') and mapping.pv_multiplier is not None:
+                        record.multiplier = mapping.pv_multiplier
+                    if hasattr(mapping, 'pv_offset') and mapping.pv_offset is not None:
+                        record.offset = mapping.pv_offset
+                    return record
             else:
                 return None
 
@@ -275,6 +324,18 @@ class RevPiEpics:
             RuntimeError: If synchronization thread fails to initialize
         """
         try:
+            # Configure autosave if globally enabled
+            if cls._autosave:
+                if cls._autosave_dir:
+                    autosave.configure(
+                        directory=cls._autosave_dir,
+                        name=cls._autosave_name,
+                        save_period=cls._autosave_period
+                    )
+                    logger.debug(f"Autosave enabled in {cls._autosave_dir}")
+                else:
+                    logger.warning("Autosave est activé (autosave=True) mais 'autosave_dir' est manquant ! La sauvegarde ne démarrera pas.")
+
             # Load EPICS database with all created PVs
             builder.LoadDatabase()
 


### PR DESCRIPTION
# Release Notes - RevPiEpics v0.2.1

## What's New: Architecture, Flexibility, and Autosave

### 1. Internal Architecture Refactoring (IOMap)
The monolithic `IOMap` object has been refactored into a cleaner object-oriented hierarchy. Analog inputs/outputs now use the `AnalogIOMap` class, which reduces the memory footprint for simple binary signals and removes numerous redundant conditional checks.

### 2. Native Autosave Integration (softioc.autosave)
It is now possible to enable automatic backup of EPICS configuration states:
- **Global Activation:** In `RevPiEpics.init(..., autosave=True, autosave_dir="/tmp/save")`.
- **Granular Control:** When creating an analog PV, you can specify `autosave_multiplier=True` or `autosave_offset=True` to specifically save these parameters to the `.softsav` file.
- The standard `autosave=...` parameter for primary variables is fully supported out of the box (e.g., `autosave=["PREC", "EGU", "VAL"]`).

### 3. Simplified Software Scaling (Float PVs)
The previous behavior that generated an integer "DIVISOR" PV has been safely removed. The system now strictly relies on a `:MULTIPLIER` and an `:OFFSET`. Both PVs are now exported as Floating-point Records (`aOut`). They fully accept standard decimal computations (e.g. `0.1` instead of dividing by `10`) and negative values.

### 4. Direct Scaling Parameter Setup
When building an analog I/O, developers can disregard PiCtory's system hardware defaults and manually inject the soft EPICS startup configuration straight from python:
`RevPiEpics.builder("IN1", initial_multiplier=1.5, initial_offset=20.0)`

### 5. Enriched Object API
The `RecordWrapper` Python object returned by `RevPiEpics.builder(...)` when targeting an analog module now structurally integrates its child scaling records. You can dynamically drive tracking parameters from Python execution logic: `my_sensor.offset.set(10)`.

---

## AIO Engine Core Mechanics (Reminder)

### Delegated Mathematical Computation (SoftIOC)
At initialization, the system imports the software parameters mapped in PiCtory to establish an absolute factory baseline. The new scalable conversion is managed entirely by live synchronized computations across the soft PV backend (`pvsync.py`).

### Real-time EPICS Editing
An operator can freely modify the mapped Soft PVs (like `caput IN2_1:MULTIPLIER 0.5`) to instantly adjust the underlying behavior:
* **Reading (IN)**: Inverse calculation from the initial raw binary value scaling back to base zero, subsequently layered dynamically beneath the new EPICS ratio.
* **Writing (OUT)**: Resolves the SCADA request according to the EPICS layer, then translates and applies the factory hardware ratio to pipeline directly to the Digital-to-Analog hardware converter.
